### PR TITLE
Adding test for directoryExists()

### DIFF
--- a/ZipArchiveAdapterTestCase.php
+++ b/ZipArchiveAdapterTestCase.php
@@ -127,6 +127,20 @@ abstract class ZipArchiveAdapterTestCase extends FilesystemAdapterTestCase
     /**
      * @test
      */
+    public function test_directory_existence(): void
+    {
+        $this->givenWeHaveAnExistingFile('a.txt');
+        $this->givenWeHaveAnExistingFile('one/a.txt');
+
+        $this->assertTrue($this->adapter()->directoryExists('one'));
+        $this->assertFalse($this->adapter()->directoryExists('two'));
+        $this->assertTrue($this->adapter()->directoryExists('/'));
+        $this->assertTrue($this->adapter()->directoryExists(''));
+    }
+
+    /**
+     * @test
+     */
     public function deleting_a_directory(): void
     {
         $this->givenWeHaveAnExistingFile('a.txt');


### PR DESCRIPTION
Reproducing error when trying to test if the directory `""` (empty string) exists:

> [ValueError]                                                 
  ZipArchive::statName(): Argument #1 ($name) cannot be empty

I think it should return true to mean, because if a zip adapter is mounted under `z://` in the `MountManager`, if we end up testing that `z://` exists, the `MountManager` will call `$adapter->directoryExists('')`